### PR TITLE
Introduce case expression syntax

### DIFF
--- a/boreal.cabal
+++ b/boreal.cabal
@@ -69,6 +69,7 @@ library
     , containers
     , effectful-core
     , extra
+    , pretty-simple
     , prettyprinter
     , prettyprinter-ansi-terminal
     , PyF
@@ -112,9 +113,10 @@ test-suite boreal-test
 
   hs-source-dirs: test
   build-depends:
-    , base          >=4.18 && <5
+    , base           >=4.18 && <5
     , boreal
     , bytestring
+    , pretty-simple
     , PyF
     , tasty
     , tasty-focus
@@ -122,4 +124,5 @@ test-suite boreal-test
     , tasty-hunit
     , text
     , text-display
+    , tree-diff
     , vector

--- a/src/Boreal/Frontend/Syntax.hs
+++ b/src/Boreal/Frontend/Syntax.hs
@@ -4,6 +4,7 @@ import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text.Read qualified as Text
 import Data.Vector (Vector)
+import GHC.Generics (Generic)
 
 type Name = Text
 
@@ -19,7 +20,7 @@ data Syntax
     BorealAtom Name
   | BorealIdent Name
   | Missing
-  deriving stock (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Generic)
 
 isAtom :: Text -> Bool
 isAtom t =
@@ -35,3 +36,7 @@ isAtom t =
         , "in"
         , "="
         ]
+
+isNamedNode :: Name -> Syntax -> Bool
+isNamedNode name (BorealNode name' _) | name == name' = True
+isNamedNode _ _ = False

--- a/src/Boreal/IR/ANFCore.hs
+++ b/src/Boreal/IR/ANFCore.hs
@@ -16,6 +16,7 @@ import Effectful.State.Static.Local qualified as State
 import Boreal.Frontend.Syntax
 import Boreal.IR.RawCore (RawCore (..))
 import Debug.Trace
+import GHC.Generics (Generic)
 
 type ANFCoreEff =
   Eff '[Reader Counter, State Bindings, IOE]
@@ -57,7 +58,7 @@ runANFCore inputCore = do
 data TerminalValue
   = ALiteral Int
   | AVar Name
-  deriving stock (Eq, Show, Ord)
+  deriving stock (Eq, Show, Ord, Generic)
 
 data ComplexValue
   = AApp
@@ -65,7 +66,7 @@ data ComplexValue
       -- ^ Function we are applying
       (Vector TerminalValue)
       -- ^ Arguments that need no further evaluation
-  deriving stock (Eq, Show, Ord)
+  deriving stock (Eq, Show, Ord, Generic)
 
 getName :: ComplexValue -> Name
 getName (AApp n _) = n
@@ -73,7 +74,7 @@ getName (AApp n _) = n
 data Value
   = Terminal TerminalValue
   | Complex ComplexValue
-  deriving stock (Eq, Show, Ord)
+  deriving stock (Eq, Show, Ord, Generic)
 
 -- | A-Normal Form AST more suitable for code generation.
 data ANFCore
@@ -89,7 +90,7 @@ data ANFCore
       Name
       (Vector Name)
       ANFCore
-  deriving stock (Eq, Show, Ord)
+  deriving stock (Eq, Show, Ord, Generic)
 
 transformName :: RawCore -> ANFCoreEff TerminalValue
 transformName core = do

--- a/src/Boreal/IR/RawCore.hs
+++ b/src/Boreal/IR/RawCore.hs
@@ -7,6 +7,7 @@ import Data.Text.Read qualified as Text
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
 import Effectful
+import GHC.Generics (Generic)
 
 -- | Non-ANF intermediate representation whose job is to take a 'Syntax'
 -- and hold it in a more convenient way for ANF transformation.
@@ -28,7 +29,7 @@ data RawCore
       -- ^ Bound expression
       RawCore
       -- ^ Body
-  deriving stock (Eq, Show, Ord)
+  deriving stock (Eq, Show, Ord, Generic)
 
 type RawCoreEff = Eff '[IOE]
 
@@ -70,6 +71,7 @@ transform (BorealNode "function_declaration" rest) = do
 transform e = error $ "Unmatched: " <> show e
 
 transformExpression :: Syntax -> RawCoreEff RawCore
+transformExpression (BorealNode "simple_expression" body) = transformExpression $ Vector.head body
 transformExpression (BorealNode "let_binding" bindings) =
   transformLetBinding (bindings Vector.! 0)
 transformExpression (BorealNode n args) = do

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,8 +1,38 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Utils where
 
+import Boreal.Frontend.Syntax
+import Boreal.IR.ANFCore
+import Boreal.IR.RawCore
+import Control.Monad (unless)
+import Data.TreeDiff
 import GHC.Stack
+import Test.Tasty.HUnit (Assertion)
 import Test.Tasty.HUnit qualified as Test
 
 assertRight :: (HasCallStack) => Either a b -> IO b
 assertRight (Left _a) = Test.assertFailure "Test return Left instead of Right"
 assertRight (Right b) = pure b
+
+assertEqualExpr
+  :: (HasCallStack, ToExpr a, Eq a)
+  => a
+  -- ^ Actual
+  -> a
+  -- ^ Expected
+  -> Assertion
+assertEqualExpr actual expected =
+  unless
+    (actual == expected)
+    ( Test.assertFailure
+        ( show $ ppEditExpr ansiWlPretty $ ediff actual expected
+        )
+    )
+
+instance ToExpr Syntax
+instance ToExpr RawCore
+instance ToExpr TerminalValue
+instance ToExpr ComplexValue
+instance ToExpr Value
+instance ToExpr ANFCore

--- a/tree-sitter-boreal/case_expression.bor
+++ b/tree-sitter-boreal/case_expression.bor
@@ -1,0 +1,6 @@
+module Expressions where
+
+expr x =
+  case x of
+    | True -> False
+    | False -> True

--- a/tree-sitter-boreal/grammar.js
+++ b/tree-sitter-boreal/grammar.js
@@ -1,58 +1,92 @@
 module.exports = grammar({
   name: "boreal",
+  // word: $ => $.identifier,
   rules: {
-      source_file: $ => seq(
-        $.module_declaration,
-        $.top_level_declarations
-      ),
+    source_file: $ => seq(
+      $.module_declaration,
+      $.top_level_declarations
+    ),
 
-      module_declaration: $ => seq(
-        "module",
-        $.module_name,
-        "where"
-      ),
+    module_declaration: $ => seq(
+      "module",
+      $.module_name,
+      "where"
+    ),
 
-      module_name: $ => /[A-Za-z]+/,
+    module_name: $ => /[A-Za-z]+/,
 
-      top_level_declarations: $ => repeat1(choice(
-        $.function_declaration
-      )),
+    top_level_declarations: $ => repeat1(choice(
+      $.function_declaration
+    )),
 
-      function_declaration: $ => seq(
-        field("head", repeat($.identifier)), 
-        "=",
-        field("body", $.function_body)
-      ),
+    function_head: $ => repeat1($.identifier),
+    function_declaration: $ => seq(
+      field("head", $.function_head),
+      "=",
+      field("body", $.function_body)
+    ),
 
-      function_body: $ => choice(
-        $.let_binding,
-        $.expression
-      ),
+    function_body: $ => choice(
+      field("case_expression", $.case_expression),
+      $.let_binding,
+      $.simple_expression,
+    ),
 
-      expression: $ => choice(
-        $.identifier,
-        $.binary_operation,
-      ),
+    simple_expression: $ => choice(
+      $.identifier,
+      $.constructor,
+      $.binary_operation,
+    ),
 
-      let_binding: $ => seq(
-        "let",
-        field("binding_name", $.identifier),
-        "=",
-        field("binding_value", $.expression),
-        "in",
-        field("binding_body", $.expression)
-      ),
-      
-      identifier: $ => /[a-z_\d]+/,
-      node: $ => choice(
-        $.binary_operation
-      ),
+    let_binding_body: $ => choice(
+      $.simple_expression
+    ),
 
-      binary_operation: $ => choice(
-        prec.left(1, seq($.expression, "+", $.expression)),
-        prec.left(2, seq($.expression, "-", $.expression)),
-        prec.left(3, seq($.expression, "*", $.expression)),
-        prec.left(4, seq($.expression, "/", $.expression)),
-      ),
-    }
+    let_binding: $ => seq(
+      "let",
+      field("binding_name", $.identifier),
+      "=",
+      field("binding_value", $.simple_expression),
+      "in",
+      field("binding_body", $.simple_expression)
+    ),
+
+    case_expression: $ => prec.right(2,seq(
+      "case",
+      field("conditional", $.simple_expression),
+      "of",
+      field("alternatives", repeat1($.alternatives))
+    )),
+
+    alternatives: $ => prec.right(seq(
+      "|",
+      sep1("|", $.alternative),
+    )),
+
+    alternative: $ => seq(
+      field("pattern", $.pattern),
+      "->",
+      field("rhs", $.simple_expression),
+    ),
+
+    node: $ => choice(
+      $.binary_operation
+    ),
+
+    pattern: $ => $.constructor,
+
+    identifier: $ => /[a-z_\d]+/,
+    constructor: $ => /[A-Z][A-Za-z0-9]+/,
+
+    binary_operation: $ => choice(
+      prec.left(1, seq($.simple_expression, "+", $.simple_expression)),
+      prec.left(2, seq($.simple_expression, "-", $.simple_expression)),
+      prec.left(3, seq($.simple_expression, "*", $.simple_expression)),
+      prec.left(4, seq($.simple_expression, "/", $.simple_expression)),
+    ),
+  }
 })
+
+function sep1(delimiter, rule) {
+  return seq(rule, repeat(seq(delimiter, rule)))
+}

--- a/tree-sitter-boreal/src/grammar.json
+++ b/tree-sitter-boreal/src/grammar.json
@@ -47,6 +47,13 @@
         ]
       }
     },
+    "function_head": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "identifier"
+      }
+    },
     "function_declaration": {
       "type": "SEQ",
       "members": [
@@ -54,11 +61,8 @@
           "type": "FIELD",
           "name": "head",
           "content": {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "identifier"
-            }
+            "type": "SYMBOL",
+            "name": "function_head"
           }
         },
         {
@@ -79,16 +83,24 @@
       "type": "CHOICE",
       "members": [
         {
+          "type": "FIELD",
+          "name": "case_expression",
+          "content": {
+            "type": "SYMBOL",
+            "name": "case_expression"
+          }
+        },
+        {
           "type": "SYMBOL",
           "name": "let_binding"
         },
         {
           "type": "SYMBOL",
-          "name": "expression"
+          "name": "simple_expression"
         }
       ]
     },
-    "expression": {
+    "simple_expression": {
       "type": "CHOICE",
       "members": [
         {
@@ -97,7 +109,20 @@
         },
         {
           "type": "SYMBOL",
+          "name": "constructor"
+        },
+        {
+          "type": "SYMBOL",
           "name": "binary_operation"
+        }
+      ]
+    },
+    "let_binding_body": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "simple_expression"
         }
       ]
     },
@@ -125,7 +150,7 @@
           "name": "binding_value",
           "content": {
             "type": "SYMBOL",
-            "name": "expression"
+            "name": "simple_expression"
           }
         },
         {
@@ -137,14 +162,109 @@
           "name": "binding_body",
           "content": {
             "type": "SYMBOL",
-            "name": "expression"
+            "name": "simple_expression"
           }
         }
       ]
     },
-    "identifier": {
-      "type": "PATTERN",
-      "value": "[a-z_\\d]+"
+    "case_expression": {
+      "type": "PREC_RIGHT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "case"
+          },
+          {
+            "type": "FIELD",
+            "name": "conditional",
+            "content": {
+              "type": "SYMBOL",
+              "name": "simple_expression"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "of"
+          },
+          {
+            "type": "FIELD",
+            "name": "alternatives",
+            "content": {
+              "type": "REPEAT1",
+              "content": {
+                "type": "SYMBOL",
+                "name": "alternatives"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "alternatives": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "|"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "alternative"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "|"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "alternative"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "alternative": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "pattern",
+          "content": {
+            "type": "SYMBOL",
+            "name": "pattern"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "->"
+        },
+        {
+          "type": "FIELD",
+          "name": "rhs",
+          "content": {
+            "type": "SYMBOL",
+            "name": "simple_expression"
+          }
+        }
+      ]
     },
     "node": {
       "type": "CHOICE",
@@ -154,6 +274,18 @@
           "name": "binary_operation"
         }
       ]
+    },
+    "pattern": {
+      "type": "SYMBOL",
+      "name": "constructor"
+    },
+    "identifier": {
+      "type": "PATTERN",
+      "value": "[a-z_\\d]+"
+    },
+    "constructor": {
+      "type": "PATTERN",
+      "value": "[A-Z][A-Za-z0-9]+"
     },
     "binary_operation": {
       "type": "CHOICE",
@@ -166,7 +298,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "expression"
+                "name": "simple_expression"
               },
               {
                 "type": "STRING",
@@ -174,7 +306,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "expression"
+                "name": "simple_expression"
               }
             ]
           }
@@ -187,7 +319,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "expression"
+                "name": "simple_expression"
               },
               {
                 "type": "STRING",
@@ -195,7 +327,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "expression"
+                "name": "simple_expression"
               }
             ]
           }
@@ -208,7 +340,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "expression"
+                "name": "simple_expression"
               },
               {
                 "type": "STRING",
@@ -216,7 +348,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "expression"
+                "name": "simple_expression"
               }
             ]
           }
@@ -229,7 +361,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "expression"
+                "name": "simple_expression"
               },
               {
                 "type": "STRING",
@@ -237,7 +369,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "expression"
+                "name": "simple_expression"
               }
             ]
           }

--- a/tree-sitter-boreal/src/node-types.json
+++ b/tree-sitter-boreal/src/node-types.json
@@ -1,5 +1,46 @@
 [
   {
+    "type": "alternative",
+    "named": true,
+    "fields": {
+      "pattern": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "pattern",
+            "named": true
+          }
+        ]
+      },
+      "rhs": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "simple_expression",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "alternatives",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alternative",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "binary_operation",
     "named": true,
     "fields": {},
@@ -8,45 +49,63 @@
       "required": true,
       "types": [
         {
-          "type": "expression",
+          "type": "simple_expression",
           "named": true
         }
       ]
     }
   },
   {
-    "type": "expression",
+    "type": "case_expression",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "binary_operation",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        }
-      ]
+    "fields": {
+      "alternatives": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "alternatives",
+            "named": true
+          }
+        ]
+      },
+      "conditional": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "simple_expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
     "type": "function_body",
     "named": true,
-    "fields": {},
+    "fields": {
+      "case_expression": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "case_expression",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
-          "type": "expression",
+          "type": "let_binding",
           "named": true
         },
         {
-          "type": "let_binding",
+          "type": "simple_expression",
           "named": true
         }
       ]
@@ -67,15 +126,30 @@
         ]
       },
       "head": {
-        "multiple": true,
-        "required": false,
+        "multiple": false,
+        "required": true,
         "types": [
           {
-            "type": "identifier",
+            "type": "function_head",
             "named": true
           }
         ]
       }
+    }
+  },
+  {
+    "type": "function_head",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -87,7 +161,7 @@
         "required": true,
         "types": [
           {
-            "type": "expression",
+            "type": "simple_expression",
             "named": true
           }
         ]
@@ -107,7 +181,7 @@
         "required": true,
         "types": [
           {
-            "type": "expression",
+            "type": "simple_expression",
             "named": true
           }
         ]
@@ -124,6 +198,44 @@
       "types": [
         {
           "type": "module_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "pattern",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "constructor",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "simple_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "binary_operation",
+          "named": true
+        },
+        {
+          "type": "constructor",
+          "named": true
+        },
+        {
+          "type": "identifier",
           "named": true
         }
       ]
@@ -176,12 +288,24 @@
     "named": false
   },
   {
+    "type": "->",
+    "named": false
+  },
+  {
     "type": "/",
     "named": false
   },
   {
     "type": "=",
     "named": false
+  },
+  {
+    "type": "case",
+    "named": false
+  },
+  {
+    "type": "constructor",
+    "named": true
   },
   {
     "type": "identifier",
@@ -204,7 +328,15 @@
     "named": true
   },
   {
+    "type": "of",
+    "named": false
+  },
+  {
     "type": "where",
+    "named": false
+  },
+  {
+    "type": "|",
     "named": false
   }
 ]

--- a/tree-sitter-boreal/src/parser.c
+++ b/tree-sitter-boreal/src/parser.c
@@ -6,15 +6,15 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 42
+#define STATE_COUNT 57
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 22
+#define SYMBOL_COUNT 34
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 12
+#define TOKEN_COUNT 17
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 5
+#define FIELD_COUNT 10
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
-#define PRODUCTION_ID_COUNT 4
+#define PRODUCTION_ID_COUNT 6
 
 enum {
   anon_sym_module = 1,
@@ -23,21 +23,33 @@ enum {
   anon_sym_EQ = 4,
   anon_sym_let = 5,
   anon_sym_in = 6,
-  sym_identifier = 7,
-  anon_sym_PLUS = 8,
-  anon_sym_DASH = 9,
-  anon_sym_STAR = 10,
-  anon_sym_SLASH = 11,
-  sym_source_file = 12,
-  sym_module_declaration = 13,
-  sym_top_level_declarations = 14,
-  sym_function_declaration = 15,
-  sym_function_body = 16,
-  sym_expression = 17,
-  sym_let_binding = 18,
-  sym_binary_operation = 19,
-  aux_sym_top_level_declarations_repeat1 = 20,
-  aux_sym_function_declaration_repeat1 = 21,
+  anon_sym_case = 7,
+  anon_sym_of = 8,
+  anon_sym_PIPE = 9,
+  anon_sym_DASH_GT = 10,
+  sym_identifier = 11,
+  sym_constructor = 12,
+  anon_sym_PLUS = 13,
+  anon_sym_DASH = 14,
+  anon_sym_STAR = 15,
+  anon_sym_SLASH = 16,
+  sym_source_file = 17,
+  sym_module_declaration = 18,
+  sym_top_level_declarations = 19,
+  sym_function_head = 20,
+  sym_function_declaration = 21,
+  sym_function_body = 22,
+  sym_simple_expression = 23,
+  sym_let_binding = 24,
+  sym_case_expression = 25,
+  sym_alternatives = 26,
+  sym_alternative = 27,
+  sym_pattern = 28,
+  sym_binary_operation = 29,
+  aux_sym_top_level_declarations_repeat1 = 30,
+  aux_sym_function_head_repeat1 = 31,
+  aux_sym_case_expression_repeat1 = 32,
+  aux_sym_alternatives_repeat1 = 33,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -48,7 +60,12 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_EQ] = "=",
   [anon_sym_let] = "let",
   [anon_sym_in] = "in",
+  [anon_sym_case] = "case",
+  [anon_sym_of] = "of",
+  [anon_sym_PIPE] = "|",
+  [anon_sym_DASH_GT] = "->",
   [sym_identifier] = "identifier",
+  [sym_constructor] = "constructor",
   [anon_sym_PLUS] = "+",
   [anon_sym_DASH] = "-",
   [anon_sym_STAR] = "*",
@@ -56,13 +73,20 @@ static const char * const ts_symbol_names[] = {
   [sym_source_file] = "source_file",
   [sym_module_declaration] = "module_declaration",
   [sym_top_level_declarations] = "top_level_declarations",
+  [sym_function_head] = "function_head",
   [sym_function_declaration] = "function_declaration",
   [sym_function_body] = "function_body",
-  [sym_expression] = "expression",
+  [sym_simple_expression] = "simple_expression",
   [sym_let_binding] = "let_binding",
+  [sym_case_expression] = "case_expression",
+  [sym_alternatives] = "alternatives",
+  [sym_alternative] = "alternative",
+  [sym_pattern] = "pattern",
   [sym_binary_operation] = "binary_operation",
   [aux_sym_top_level_declarations_repeat1] = "top_level_declarations_repeat1",
-  [aux_sym_function_declaration_repeat1] = "function_declaration_repeat1",
+  [aux_sym_function_head_repeat1] = "function_head_repeat1",
+  [aux_sym_case_expression_repeat1] = "case_expression_repeat1",
+  [aux_sym_alternatives_repeat1] = "alternatives_repeat1",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -73,7 +97,12 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_EQ] = anon_sym_EQ,
   [anon_sym_let] = anon_sym_let,
   [anon_sym_in] = anon_sym_in,
+  [anon_sym_case] = anon_sym_case,
+  [anon_sym_of] = anon_sym_of,
+  [anon_sym_PIPE] = anon_sym_PIPE,
+  [anon_sym_DASH_GT] = anon_sym_DASH_GT,
   [sym_identifier] = sym_identifier,
+  [sym_constructor] = sym_constructor,
   [anon_sym_PLUS] = anon_sym_PLUS,
   [anon_sym_DASH] = anon_sym_DASH,
   [anon_sym_STAR] = anon_sym_STAR,
@@ -81,13 +110,20 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_source_file] = sym_source_file,
   [sym_module_declaration] = sym_module_declaration,
   [sym_top_level_declarations] = sym_top_level_declarations,
+  [sym_function_head] = sym_function_head,
   [sym_function_declaration] = sym_function_declaration,
   [sym_function_body] = sym_function_body,
-  [sym_expression] = sym_expression,
+  [sym_simple_expression] = sym_simple_expression,
   [sym_let_binding] = sym_let_binding,
+  [sym_case_expression] = sym_case_expression,
+  [sym_alternatives] = sym_alternatives,
+  [sym_alternative] = sym_alternative,
+  [sym_pattern] = sym_pattern,
   [sym_binary_operation] = sym_binary_operation,
   [aux_sym_top_level_declarations_repeat1] = aux_sym_top_level_declarations_repeat1,
-  [aux_sym_function_declaration_repeat1] = aux_sym_function_declaration_repeat1,
+  [aux_sym_function_head_repeat1] = aux_sym_function_head_repeat1,
+  [aux_sym_case_expression_repeat1] = aux_sym_case_expression_repeat1,
+  [aux_sym_alternatives_repeat1] = aux_sym_alternatives_repeat1,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -119,7 +155,27 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [anon_sym_case] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_of] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_PIPE] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DASH_GT] = {
+    .visible = true,
+    .named = false,
+  },
   [sym_identifier] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_constructor] = {
     .visible = true,
     .named = true,
   },
@@ -151,6 +207,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_function_head] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_function_declaration] = {
     .visible = true,
     .named = true,
@@ -159,11 +219,27 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_expression] = {
+  [sym_simple_expression] = {
     .visible = true,
     .named = true,
   },
   [sym_let_binding] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_case_expression] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_alternatives] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_alternative] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_pattern] = {
     .visible = true,
     .named = true,
   },
@@ -175,45 +251,71 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_function_declaration_repeat1] = {
+  [aux_sym_function_head_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_case_expression_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_alternatives_repeat1] = {
     .visible = false,
     .named = false,
   },
 };
 
 enum {
-  field_binding_body = 1,
-  field_binding_name = 2,
-  field_binding_value = 3,
-  field_body = 4,
-  field_head = 5,
+  field_alternatives = 1,
+  field_binding_body = 2,
+  field_binding_name = 3,
+  field_binding_value = 4,
+  field_body = 5,
+  field_case_expression = 6,
+  field_conditional = 7,
+  field_head = 8,
+  field_pattern = 9,
+  field_rhs = 10,
 };
 
 static const char * const ts_field_names[] = {
   [0] = NULL,
+  [field_alternatives] = "alternatives",
   [field_binding_body] = "binding_body",
   [field_binding_name] = "binding_name",
   [field_binding_value] = "binding_value",
   [field_body] = "body",
+  [field_case_expression] = "case_expression",
+  [field_conditional] = "conditional",
   [field_head] = "head",
+  [field_pattern] = "pattern",
+  [field_rhs] = "rhs",
 };
 
 static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
-  [1] = {.index = 0, .length = 1},
-  [2] = {.index = 1, .length = 2},
-  [3] = {.index = 3, .length = 3},
+  [1] = {.index = 0, .length = 2},
+  [2] = {.index = 2, .length = 1},
+  [3] = {.index = 3, .length = 2},
+  [4] = {.index = 5, .length = 3},
+  [5] = {.index = 8, .length = 2},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
   [0] =
-    {field_body, 1},
-  [1] =
     {field_body, 2},
     {field_head, 0},
+  [2] =
+    {field_case_expression, 0},
   [3] =
+    {field_alternatives, 3},
+    {field_conditional, 1},
+  [5] =
     {field_binding_body, 5},
     {field_binding_name, 1},
     {field_binding_value, 3},
+  [8] =
+    {field_pattern, 0},
+    {field_rhs, 2},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
@@ -234,32 +336,32 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [6] = 6,
   [7] = 7,
   [8] = 8,
-  [9] = 9,
-  [10] = 10,
+  [9] = 4,
+  [10] = 8,
   [11] = 11,
   [12] = 12,
   [13] = 13,
-  [14] = 4,
-  [15] = 6,
+  [14] = 6,
+  [15] = 15,
   [16] = 7,
-  [17] = 8,
-  [18] = 3,
+  [17] = 17,
+  [18] = 5,
   [19] = 19,
   [20] = 20,
   [21] = 21,
-  [22] = 21,
+  [22] = 22,
   [23] = 23,
   [24] = 24,
   [25] = 25,
   [26] = 26,
-  [27] = 23,
-  [28] = 28,
-  [29] = 29,
+  [27] = 27,
+  [28] = 26,
+  [29] = 25,
   [30] = 30,
   [31] = 31,
-  [32] = 32,
-  [33] = 32,
-  [34] = 20,
+  [32] = 30,
+  [33] = 31,
+  [34] = 34,
   [35] = 35,
   [36] = 36,
   [37] = 37,
@@ -267,6 +369,21 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [39] = 39,
   [40] = 40,
   [41] = 41,
+  [42] = 42,
+  [43] = 43,
+  [44] = 44,
+  [45] = 45,
+  [46] = 46,
+  [47] = 47,
+  [48] = 48,
+  [49] = 49,
+  [50] = 50,
+  [51] = 51,
+  [52] = 52,
+  [53] = 53,
+  [54] = 54,
+  [55] = 55,
+  [56] = 56,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -274,149 +391,239 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(16);
-      if (lookahead == '*') ADVANCE(29);
-      if (lookahead == '+') ADVANCE(27);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '/') ADVANCE(30);
-      if (lookahead == '=') ADVANCE(20);
-      if (lookahead == 'i') ADVANCE(9);
-      if (lookahead == 'l') ADVANCE(2);
-      if (lookahead == 'm') ADVANCE(10);
-      if (lookahead == 'w') ADVANCE(6);
+      if (eof) ADVANCE(23);
+      if (lookahead == '*') ADVANCE(46);
+      if (lookahead == '+') ADVANCE(43);
+      if (lookahead == '-') ADVANCE(45);
+      if (lookahead == '/') ADVANCE(47);
+      if (lookahead == '=') ADVANCE(27);
+      if (lookahead == 'c') ADVANCE(4);
+      if (lookahead == 'i') ADVANCE(14);
+      if (lookahead == 'l') ADVANCE(6);
+      if (lookahead == 'm') ADVANCE(15);
+      if (lookahead == 'o') ADVANCE(11);
+      if (lookahead == 'w') ADVANCE(12);
+      if (lookahead == '|') ADVANCE(34);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(21);
       END_STATE();
     case 1:
-      if (lookahead == 'd') ADVANCE(13);
+      if (lookahead == '*') ADVANCE(46);
+      if (lookahead == '+') ADVANCE(43);
+      if (lookahead == '-') ADVANCE(44);
+      if (lookahead == '/') ADVANCE(47);
+      if (lookahead == 'i') ADVANCE(14);
+      if (lookahead == 'o') ADVANCE(11);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(1)
       END_STATE();
     case 2:
-      if (lookahead == 'e') ADVANCE(12);
+      if (lookahead == '-') ADVANCE(3);
+      if (lookahead == 'c') ADVANCE(36);
+      if (lookahead == 'l') ADVANCE(37);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(2)
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(21);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(41);
       END_STATE();
     case 3:
-      if (lookahead == 'e') ADVANCE(11);
+      if (lookahead == '>') ADVANCE(35);
       END_STATE();
     case 4:
-      if (lookahead == 'e') ADVANCE(18);
+      if (lookahead == 'a') ADVANCE(17);
       END_STATE();
     case 5:
-      if (lookahead == 'e') ADVANCE(17);
+      if (lookahead == 'd') ADVANCE(19);
       END_STATE();
     case 6:
-      if (lookahead == 'h') ADVANCE(3);
+      if (lookahead == 'e') ADVANCE(18);
       END_STATE();
     case 7:
-      if (lookahead == 'l') ADVANCE(24);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(7)
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      if (lookahead == 'e') ADVANCE(16);
       END_STATE();
     case 8:
-      if (lookahead == 'l') ADVANCE(5);
+      if (lookahead == 'e') ADVANCE(31);
       END_STATE();
     case 9:
-      if (lookahead == 'n') ADVANCE(23);
+      if (lookahead == 'e') ADVANCE(25);
       END_STATE();
     case 10:
-      if (lookahead == 'o') ADVANCE(1);
+      if (lookahead == 'e') ADVANCE(24);
       END_STATE();
     case 11:
-      if (lookahead == 'r') ADVANCE(4);
+      if (lookahead == 'f') ADVANCE(33);
       END_STATE();
     case 12:
-      if (lookahead == 't') ADVANCE(21);
+      if (lookahead == 'h') ADVANCE(7);
       END_STATE();
     case 13:
-      if (lookahead == 'u') ADVANCE(8);
+      if (lookahead == 'l') ADVANCE(10);
       END_STATE();
     case 14:
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(14)
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(19);
+      if (lookahead == 'n') ADVANCE(30);
       END_STATE();
     case 15:
-      if (eof) ADVANCE(16);
-      if (lookahead == '*') ADVANCE(29);
-      if (lookahead == '+') ADVANCE(27);
-      if (lookahead == '-') ADVANCE(28);
-      if (lookahead == '/') ADVANCE(30);
-      if (lookahead == '=') ADVANCE(20);
+      if (lookahead == 'o') ADVANCE(5);
+      END_STATE();
+    case 16:
+      if (lookahead == 'r') ADVANCE(9);
+      END_STATE();
+    case 17:
+      if (lookahead == 's') ADVANCE(8);
+      END_STATE();
+    case 18:
+      if (lookahead == 't') ADVANCE(28);
+      END_STATE();
+    case 19:
+      if (lookahead == 'u') ADVANCE(13);
+      END_STATE();
+    case 20:
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(15)
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
-      END_STATE();
-    case 16:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 17:
-      ACCEPT_TOKEN(anon_sym_module);
-      END_STATE();
-    case 18:
-      ACCEPT_TOKEN(anon_sym_where);
-      END_STATE();
-    case 19:
-      ACCEPT_TOKEN(sym_module_name);
+          lookahead == ' ') SKIP(20)
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(19);
-      END_STATE();
-    case 20:
-      ACCEPT_TOKEN(anon_sym_EQ);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
       END_STATE();
     case 21:
-      ACCEPT_TOKEN(anon_sym_let);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(42);
       END_STATE();
     case 22:
-      ACCEPT_TOKEN(anon_sym_let);
+      if (eof) ADVANCE(23);
+      if (lookahead == '*') ADVANCE(46);
+      if (lookahead == '+') ADVANCE(43);
+      if (lookahead == '-') ADVANCE(44);
+      if (lookahead == '/') ADVANCE(47);
+      if (lookahead == '=') ADVANCE(27);
+      if (lookahead == '|') ADVANCE(34);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(22)
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(21);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(41);
       END_STATE();
     case 23:
-      ACCEPT_TOKEN(anon_sym_in);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 24:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(25);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      ACCEPT_TOKEN(anon_sym_module);
       END_STATE();
     case 25:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      ACCEPT_TOKEN(anon_sym_where);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(sym_identifier);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
+      ACCEPT_TOKEN(sym_module_name);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
       END_STATE();
     case 27:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 28:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(anon_sym_let);
       END_STATE();
     case 29:
-      ACCEPT_TOKEN(anon_sym_STAR);
+      ACCEPT_TOKEN(anon_sym_let);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(41);
       END_STATE();
     case 30:
+      ACCEPT_TOKEN(anon_sym_in);
+      END_STATE();
+    case 31:
+      ACCEPT_TOKEN(anon_sym_case);
+      END_STATE();
+    case 32:
+      ACCEPT_TOKEN(anon_sym_case);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(41);
+      END_STATE();
+    case 33:
+      ACCEPT_TOKEN(anon_sym_of);
+      END_STATE();
+    case 34:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      END_STATE();
+    case 35:
+      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      END_STATE();
+    case 36:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(39);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(41);
+      END_STATE();
+    case 37:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(40);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(41);
+      END_STATE();
+    case 38:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(32);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(41);
+      END_STATE();
+    case 39:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(38);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(41);
+      END_STATE();
+    case 40:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(29);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(41);
+      END_STATE();
+    case 41:
+      ACCEPT_TOKEN(sym_identifier);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(41);
+      END_STATE();
+    case 42:
+      ACCEPT_TOKEN(sym_constructor);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(42);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(anon_sym_PLUS);
+      END_STATE();
+    case 44:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      END_STATE();
+    case 45:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '>') ADVANCE(35);
+      END_STATE();
+    case 46:
+      ACCEPT_TOKEN(anon_sym_STAR);
+      END_STATE();
+    case 47:
       ACCEPT_TOKEN(anon_sym_SLASH);
       END_STATE();
     default:
@@ -427,46 +634,61 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
   [1] = {.lex_state = 0},
-  [2] = {.lex_state = 15},
-  [3] = {.lex_state = 15},
-  [4] = {.lex_state = 15},
-  [5] = {.lex_state = 15},
-  [6] = {.lex_state = 15},
-  [7] = {.lex_state = 15},
-  [8] = {.lex_state = 15},
-  [9] = {.lex_state = 15},
-  [10] = {.lex_state = 7},
-  [11] = {.lex_state = 15},
-  [12] = {.lex_state = 15},
-  [13] = {.lex_state = 7},
-  [14] = {.lex_state = 0},
-  [15] = {.lex_state = 0},
-  [16] = {.lex_state = 0},
-  [17] = {.lex_state = 0},
-  [18] = {.lex_state = 0},
-  [19] = {.lex_state = 0},
-  [20] = {.lex_state = 15},
-  [21] = {.lex_state = 15},
-  [22] = {.lex_state = 15},
-  [23] = {.lex_state = 15},
-  [24] = {.lex_state = 15},
-  [25] = {.lex_state = 15},
-  [26] = {.lex_state = 15},
-  [27] = {.lex_state = 15},
-  [28] = {.lex_state = 15},
-  [29] = {.lex_state = 15},
-  [30] = {.lex_state = 15},
-  [31] = {.lex_state = 15},
-  [32] = {.lex_state = 15},
-  [33] = {.lex_state = 15},
-  [34] = {.lex_state = 15},
-  [35] = {.lex_state = 15},
-  [36] = {.lex_state = 15},
-  [37] = {.lex_state = 0},
-  [38] = {.lex_state = 14},
+  [2] = {.lex_state = 2},
+  [3] = {.lex_state = 22},
+  [4] = {.lex_state = 22},
+  [5] = {.lex_state = 22},
+  [6] = {.lex_state = 22},
+  [7] = {.lex_state = 22},
+  [8] = {.lex_state = 22},
+  [9] = {.lex_state = 1},
+  [10] = {.lex_state = 1},
+  [11] = {.lex_state = 22},
+  [12] = {.lex_state = 22},
+  [13] = {.lex_state = 22},
+  [14] = {.lex_state = 1},
+  [15] = {.lex_state = 22},
+  [16] = {.lex_state = 1},
+  [17] = {.lex_state = 22},
+  [18] = {.lex_state = 1},
+  [19] = {.lex_state = 22},
+  [20] = {.lex_state = 22},
+  [21] = {.lex_state = 1},
+  [22] = {.lex_state = 1},
+  [23] = {.lex_state = 22},
+  [24] = {.lex_state = 22},
+  [25] = {.lex_state = 22},
+  [26] = {.lex_state = 22},
+  [27] = {.lex_state = 22},
+  [28] = {.lex_state = 22},
+  [29] = {.lex_state = 22},
+  [30] = {.lex_state = 22},
+  [31] = {.lex_state = 22},
+  [32] = {.lex_state = 22},
+  [33] = {.lex_state = 22},
+  [34] = {.lex_state = 22},
+  [35] = {.lex_state = 22},
+  [36] = {.lex_state = 22},
+  [37] = {.lex_state = 22},
+  [38] = {.lex_state = 22},
   [39] = {.lex_state = 0},
   [40] = {.lex_state = 0},
-  [41] = {.lex_state = 0},
+  [41] = {.lex_state = 22},
+  [42] = {.lex_state = 22},
+  [43] = {.lex_state = 0},
+  [44] = {.lex_state = 22},
+  [45] = {.lex_state = 22},
+  [46] = {.lex_state = 22},
+  [47] = {.lex_state = 2},
+  [48] = {.lex_state = 22},
+  [49] = {.lex_state = 2},
+  [50] = {.lex_state = 22},
+  [51] = {.lex_state = 0},
+  [52] = {.lex_state = 20},
+  [53] = {.lex_state = 0},
+  [54] = {.lex_state = 0},
+  [55] = {.lex_state = 0},
+  [56] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -477,416 +699,568 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_EQ] = ACTIONS(1),
     [anon_sym_let] = ACTIONS(1),
     [anon_sym_in] = ACTIONS(1),
+    [anon_sym_case] = ACTIONS(1),
+    [anon_sym_of] = ACTIONS(1),
+    [anon_sym_PIPE] = ACTIONS(1),
+    [anon_sym_DASH_GT] = ACTIONS(1),
+    [sym_constructor] = ACTIONS(1),
     [anon_sym_PLUS] = ACTIONS(1),
     [anon_sym_DASH] = ACTIONS(1),
     [anon_sym_STAR] = ACTIONS(1),
     [anon_sym_SLASH] = ACTIONS(1),
   },
   [1] = {
-    [sym_source_file] = STATE(41),
-    [sym_module_declaration] = STATE(9),
+    [sym_source_file] = STATE(56),
+    [sym_module_declaration] = STATE(17),
     [anon_sym_module] = ACTIONS(3),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 5,
+  [0] = 9,
+    ACTIONS(5), 1,
+      anon_sym_let,
     ACTIONS(7), 1,
-      anon_sym_PLUS,
+      anon_sym_case,
     ACTIONS(9), 1,
-      anon_sym_DASH,
+      sym_identifier,
     ACTIONS(11), 1,
-      anon_sym_STAR,
-    ACTIONS(13), 1,
-      anon_sym_SLASH,
-    ACTIONS(5), 3,
-      ts_builtin_sym_end,
-      anon_sym_EQ,
-      sym_identifier,
-  [18] = 1,
-    ACTIONS(15), 7,
-      ts_builtin_sym_end,
-      anon_sym_EQ,
-      sym_identifier,
+      sym_constructor,
+    STATE(8), 1,
+      sym_binary_operation,
+    STATE(15), 1,
+      sym_simple_expression,
+    STATE(44), 1,
+      sym_function_body,
+    STATE(45), 1,
+      sym_let_binding,
+    STATE(46), 1,
+      sym_case_expression,
+  [28] = 5,
+    ACTIONS(15), 1,
       anon_sym_PLUS,
+    ACTIONS(17), 1,
       anon_sym_DASH,
+    ACTIONS(19), 1,
       anon_sym_STAR,
-      anon_sym_SLASH,
-  [28] = 1,
-    ACTIONS(17), 7,
-      ts_builtin_sym_end,
-      anon_sym_EQ,
-      sym_identifier,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-  [38] = 5,
-    ACTIONS(7), 1,
-      anon_sym_PLUS,
-    ACTIONS(9), 1,
-      anon_sym_DASH,
-    ACTIONS(11), 1,
-      anon_sym_STAR,
-    ACTIONS(13), 1,
-      anon_sym_SLASH,
-    ACTIONS(19), 3,
-      ts_builtin_sym_end,
-      anon_sym_EQ,
-      sym_identifier,
-  [56] = 2,
-    ACTIONS(13), 1,
-      anon_sym_SLASH,
-    ACTIONS(17), 6,
-      ts_builtin_sym_end,
-      anon_sym_EQ,
-      sym_identifier,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_STAR,
-  [68] = 3,
-    ACTIONS(11), 1,
-      anon_sym_STAR,
-    ACTIONS(13), 1,
-      anon_sym_SLASH,
-    ACTIONS(17), 5,
-      ts_builtin_sym_end,
-      anon_sym_EQ,
-      sym_identifier,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [82] = 4,
-    ACTIONS(9), 1,
-      anon_sym_DASH,
-    ACTIONS(11), 1,
-      anon_sym_STAR,
-    ACTIONS(13), 1,
-      anon_sym_SLASH,
-    ACTIONS(17), 4,
-      ts_builtin_sym_end,
-      anon_sym_EQ,
-      sym_identifier,
-      anon_sym_PLUS,
-  [98] = 5,
     ACTIONS(21), 1,
-      anon_sym_EQ,
-    ACTIONS(23), 1,
+      anon_sym_SLASH,
+    ACTIONS(13), 3,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
       sym_identifier,
-    STATE(26), 1,
-      aux_sym_function_declaration_repeat1,
-    STATE(39), 1,
+  [46] = 3,
+    ACTIONS(19), 1,
+      anon_sym_STAR,
+    ACTIONS(21), 1,
+      anon_sym_SLASH,
+    ACTIONS(23), 5,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_identifier,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [60] = 2,
+    ACTIONS(21), 1,
+      anon_sym_SLASH,
+    ACTIONS(23), 6,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_identifier,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+  [72] = 1,
+    ACTIONS(23), 7,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_identifier,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+  [82] = 4,
+    ACTIONS(17), 1,
+      anon_sym_DASH,
+    ACTIONS(19), 1,
+      anon_sym_STAR,
+    ACTIONS(21), 1,
+      anon_sym_SLASH,
+    ACTIONS(23), 4,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_identifier,
+      anon_sym_PLUS,
+  [98] = 1,
+    ACTIONS(25), 7,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_identifier,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+  [108] = 3,
+    ACTIONS(27), 1,
+      anon_sym_STAR,
+    ACTIONS(29), 1,
+      anon_sym_SLASH,
+    ACTIONS(23), 4,
+      anon_sym_in,
+      anon_sym_of,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [121] = 1,
+    ACTIONS(25), 6,
+      anon_sym_in,
+      anon_sym_of,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+  [130] = 5,
+    ACTIONS(31), 1,
+      ts_builtin_sym_end,
+    ACTIONS(33), 1,
+      sym_identifier,
+    STATE(38), 1,
+      aux_sym_function_head_repeat1,
+    STATE(53), 1,
+      sym_function_head,
+    STATE(12), 2,
+      sym_function_declaration,
+      aux_sym_top_level_declarations_repeat1,
+  [147] = 5,
+    ACTIONS(35), 1,
+      ts_builtin_sym_end,
+    ACTIONS(37), 1,
+      sym_identifier,
+    STATE(38), 1,
+      aux_sym_function_head_repeat1,
+    STATE(53), 1,
+      sym_function_head,
+    STATE(12), 2,
+      sym_function_declaration,
+      aux_sym_top_level_declarations_repeat1,
+  [164] = 5,
+    ACTIONS(15), 1,
+      anon_sym_PLUS,
+    ACTIONS(17), 1,
+      anon_sym_DASH,
+    ACTIONS(19), 1,
+      anon_sym_STAR,
+    ACTIONS(21), 1,
+      anon_sym_SLASH,
+    ACTIONS(40), 2,
+      ts_builtin_sym_end,
+      sym_identifier,
+  [181] = 1,
+    ACTIONS(23), 6,
+      anon_sym_in,
+      anon_sym_of,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_SLASH,
+  [190] = 5,
+    ACTIONS(15), 1,
+      anon_sym_PLUS,
+    ACTIONS(17), 1,
+      anon_sym_DASH,
+    ACTIONS(19), 1,
+      anon_sym_STAR,
+    ACTIONS(21), 1,
+      anon_sym_SLASH,
+    ACTIONS(42), 2,
+      ts_builtin_sym_end,
+      sym_identifier,
+  [207] = 4,
+    ACTIONS(27), 1,
+      anon_sym_STAR,
+    ACTIONS(29), 1,
+      anon_sym_SLASH,
+    ACTIONS(44), 1,
+      anon_sym_DASH,
+    ACTIONS(23), 3,
+      anon_sym_in,
+      anon_sym_of,
+      anon_sym_PLUS,
+  [222] = 5,
+    ACTIONS(33), 1,
+      sym_identifier,
+    STATE(38), 1,
+      aux_sym_function_head_repeat1,
+    STATE(53), 1,
+      sym_function_head,
+    STATE(54), 1,
       sym_top_level_declarations,
     STATE(11), 2,
       sym_function_declaration,
       aux_sym_top_level_declarations_repeat1,
-  [115] = 6,
-    ACTIONS(25), 1,
-      anon_sym_let,
-    ACTIONS(27), 1,
-      sym_identifier,
-    STATE(3), 1,
-      sym_binary_operation,
-    STATE(5), 1,
-      sym_expression,
-    STATE(29), 1,
-      sym_let_binding,
-    STATE(30), 1,
-      sym_function_body,
-  [134] = 5,
-    ACTIONS(21), 1,
-      anon_sym_EQ,
-    ACTIONS(23), 1,
-      sym_identifier,
+  [239] = 2,
     ACTIONS(29), 1,
+      anon_sym_SLASH,
+    ACTIONS(23), 5,
+      anon_sym_in,
+      anon_sym_of,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+  [250] = 3,
+    ACTIONS(48), 1,
+      anon_sym_PIPE,
+    ACTIONS(46), 2,
       ts_builtin_sym_end,
-    STATE(26), 1,
-      aux_sym_function_declaration_repeat1,
-    STATE(12), 2,
-      sym_function_declaration,
-      aux_sym_top_level_declarations_repeat1,
-  [151] = 5,
-    ACTIONS(31), 1,
-      ts_builtin_sym_end,
-    ACTIONS(33), 1,
-      anon_sym_EQ,
-    ACTIONS(36), 1,
       sym_identifier,
-    STATE(26), 1,
-      aux_sym_function_declaration_repeat1,
-    STATE(12), 2,
-      sym_function_declaration,
-      aux_sym_top_level_declarations_repeat1,
-  [168] = 6,
-    ACTIONS(25), 1,
-      anon_sym_let,
+    STATE(19), 2,
+      sym_alternatives,
+      aux_sym_case_expression_repeat1,
+  [262] = 3,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    ACTIONS(51), 2,
+      ts_builtin_sym_end,
+      sym_identifier,
+    STATE(19), 2,
+      sym_alternatives,
+      aux_sym_case_expression_repeat1,
+  [274] = 5,
     ACTIONS(27), 1,
-      sym_identifier,
-    STATE(3), 1,
-      sym_binary_operation,
-    STATE(5), 1,
-      sym_expression,
-    STATE(24), 1,
-      sym_function_body,
-    STATE(29), 1,
-      sym_let_binding,
-  [187] = 1,
-    ACTIONS(17), 5,
-      anon_sym_in,
-      anon_sym_PLUS,
-      anon_sym_DASH,
       anon_sym_STAR,
+    ACTIONS(29), 1,
       anon_sym_SLASH,
-  [195] = 2,
-    ACTIONS(39), 1,
-      anon_sym_SLASH,
-    ACTIONS(17), 4,
-      anon_sym_in,
-      anon_sym_PLUS,
+    ACTIONS(44), 1,
       anon_sym_DASH,
-      anon_sym_STAR,
-  [205] = 3,
-    ACTIONS(39), 1,
-      anon_sym_SLASH,
-    ACTIONS(41), 1,
-      anon_sym_STAR,
-    ACTIONS(17), 3,
-      anon_sym_in,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [217] = 4,
-    ACTIONS(39), 1,
-      anon_sym_SLASH,
-    ACTIONS(41), 1,
-      anon_sym_STAR,
-    ACTIONS(43), 1,
-      anon_sym_DASH,
-    ACTIONS(17), 2,
-      anon_sym_in,
-      anon_sym_PLUS,
-  [231] = 1,
-    ACTIONS(15), 5,
-      anon_sym_in,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_SLASH,
-  [239] = 5,
-    ACTIONS(39), 1,
-      anon_sym_SLASH,
-    ACTIONS(41), 1,
-      anon_sym_STAR,
-    ACTIONS(43), 1,
-      anon_sym_DASH,
-    ACTIONS(45), 1,
-      anon_sym_in,
-    ACTIONS(47), 1,
-      anon_sym_PLUS,
-  [255] = 3,
-    ACTIONS(49), 1,
-      sym_identifier,
-    STATE(3), 1,
-      sym_binary_operation,
-    STATE(8), 1,
-      sym_expression,
-  [265] = 3,
-    ACTIONS(51), 1,
-      sym_identifier,
-    STATE(15), 1,
-      sym_expression,
-    STATE(18), 1,
-      sym_binary_operation,
-  [275] = 3,
-    ACTIONS(49), 1,
-      sym_identifier,
-    STATE(3), 1,
-      sym_binary_operation,
-    STATE(6), 1,
-      sym_expression,
-  [285] = 3,
-    ACTIONS(49), 1,
-      sym_identifier,
-    STATE(3), 1,
-      sym_binary_operation,
-    STATE(4), 1,
-      sym_expression,
-  [295] = 1,
-    ACTIONS(53), 3,
-      ts_builtin_sym_end,
-      anon_sym_EQ,
-      sym_identifier,
-  [301] = 3,
-    ACTIONS(51), 1,
-      sym_identifier,
-    STATE(18), 1,
-      sym_binary_operation,
-    STATE(19), 1,
-      sym_expression,
-  [311] = 3,
     ACTIONS(55), 1,
-      anon_sym_EQ,
+      anon_sym_in,
     ACTIONS(57), 1,
-      sym_identifier,
-    STATE(28), 1,
-      aux_sym_function_declaration_repeat1,
-  [321] = 3,
-    ACTIONS(51), 1,
-      sym_identifier,
-    STATE(14), 1,
-      sym_expression,
-    STATE(18), 1,
-      sym_binary_operation,
-  [331] = 3,
+      anon_sym_PLUS,
+  [290] = 5,
+    ACTIONS(27), 1,
+      anon_sym_STAR,
+    ACTIONS(29), 1,
+      anon_sym_SLASH,
+    ACTIONS(44), 1,
+      anon_sym_DASH,
+    ACTIONS(57), 1,
+      anon_sym_PLUS,
     ACTIONS(59), 1,
-      anon_sym_EQ,
-    ACTIONS(61), 1,
-      sym_identifier,
-    STATE(28), 1,
-      aux_sym_function_declaration_repeat1,
-  [341] = 1,
-    ACTIONS(19), 3,
+      anon_sym_of,
+  [306] = 3,
+    ACTIONS(63), 1,
+      anon_sym_PIPE,
+    STATE(34), 1,
+      aux_sym_alternatives_repeat1,
+    ACTIONS(61), 2,
       ts_builtin_sym_end,
-      anon_sym_EQ,
       sym_identifier,
-  [347] = 1,
-    ACTIONS(64), 3,
+  [317] = 3,
+    ACTIONS(63), 1,
+      anon_sym_PIPE,
+    STATE(23), 1,
+      aux_sym_alternatives_repeat1,
+    ACTIONS(65), 2,
       ts_builtin_sym_end,
-      anon_sym_EQ,
       sym_identifier,
-  [353] = 3,
-    ACTIONS(49), 1,
-      sym_identifier,
-    STATE(2), 1,
-      sym_expression,
-    STATE(3), 1,
+  [328] = 3,
+    STATE(5), 1,
+      sym_simple_expression,
+    STATE(8), 1,
       sym_binary_operation,
-  [363] = 3,
-    ACTIONS(49), 1,
+    ACTIONS(11), 2,
       sym_identifier,
-    STATE(3), 1,
+      sym_constructor,
+  [339] = 3,
+    STATE(6), 1,
+      sym_simple_expression,
+    STATE(8), 1,
       sym_binary_operation,
-    STATE(7), 1,
-      sym_expression,
-  [373] = 3,
-    ACTIONS(51), 1,
+    ACTIONS(11), 2,
       sym_identifier,
-    STATE(16), 1,
-      sym_expression,
+      sym_constructor,
+  [350] = 3,
+    STATE(10), 1,
+      sym_binary_operation,
+    STATE(21), 1,
+      sym_simple_expression,
+    ACTIONS(67), 2,
+      sym_identifier,
+      sym_constructor,
+  [361] = 3,
+    STATE(10), 1,
+      sym_binary_operation,
+    STATE(14), 1,
+      sym_simple_expression,
+    ACTIONS(67), 2,
+      sym_identifier,
+      sym_constructor,
+  [372] = 3,
+    STATE(10), 1,
+      sym_binary_operation,
     STATE(18), 1,
-      sym_binary_operation,
+      sym_simple_expression,
+    ACTIONS(67), 2,
+      sym_identifier,
+      sym_constructor,
   [383] = 3,
-    ACTIONS(51), 1,
-      sym_identifier,
-    STATE(17), 1,
-      sym_expression,
-    STATE(18), 1,
+    STATE(7), 1,
+      sym_simple_expression,
+    STATE(8), 1,
       sym_binary_operation,
-  [393] = 1,
-    ACTIONS(66), 2,
-      anon_sym_EQ,
+    ACTIONS(11), 2,
       sym_identifier,
-  [398] = 1,
-    ACTIONS(68), 1,
+      sym_constructor,
+  [394] = 3,
+    STATE(9), 1,
+      sym_simple_expression,
+    STATE(10), 1,
+      sym_binary_operation,
+    ACTIONS(67), 2,
       sym_identifier,
-  [402] = 1,
-    ACTIONS(70), 1,
-      anon_sym_EQ,
-  [406] = 1,
-    ACTIONS(72), 1,
-      sym_module_name,
-  [410] = 1,
-    ACTIONS(74), 1,
+      sym_constructor,
+  [405] = 3,
+    STATE(10), 1,
+      sym_binary_operation,
+    STATE(16), 1,
+      sym_simple_expression,
+    ACTIONS(67), 2,
+      sym_identifier,
+      sym_constructor,
+  [416] = 3,
+    STATE(4), 1,
+      sym_simple_expression,
+    STATE(8), 1,
+      sym_binary_operation,
+    ACTIONS(11), 2,
+      sym_identifier,
+      sym_constructor,
+  [427] = 3,
+    ACTIONS(71), 1,
+      anon_sym_PIPE,
+    STATE(34), 1,
+      aux_sym_alternatives_repeat1,
+    ACTIONS(69), 2,
       ts_builtin_sym_end,
-  [414] = 1,
+      sym_identifier,
+  [438] = 3,
+    STATE(3), 1,
+      sym_simple_expression,
+    STATE(8), 1,
+      sym_binary_operation,
+    ACTIONS(11), 2,
+      sym_identifier,
+      sym_constructor,
+  [449] = 3,
+    STATE(8), 1,
+      sym_binary_operation,
+    STATE(13), 1,
+      sym_simple_expression,
+    ACTIONS(11), 2,
+      sym_identifier,
+      sym_constructor,
+  [460] = 3,
+    STATE(10), 1,
+      sym_binary_operation,
+    STATE(22), 1,
+      sym_simple_expression,
+    ACTIONS(67), 2,
+      sym_identifier,
+      sym_constructor,
+  [471] = 3,
+    ACTIONS(74), 1,
+      anon_sym_EQ,
     ACTIONS(76), 1,
-      anon_sym_where,
-  [418] = 1,
+      sym_identifier,
+    STATE(41), 1,
+      aux_sym_function_head_repeat1,
+  [481] = 2,
+    ACTIONS(53), 1,
+      anon_sym_PIPE,
+    STATE(20), 2,
+      sym_alternatives,
+      aux_sym_case_expression_repeat1,
+  [489] = 3,
     ACTIONS(78), 1,
+      sym_constructor,
+    STATE(42), 1,
+      sym_alternative,
+    STATE(47), 1,
+      sym_pattern,
+  [499] = 3,
+    ACTIONS(80), 1,
+      anon_sym_EQ,
+    ACTIONS(82), 1,
+      sym_identifier,
+    STATE(41), 1,
+      aux_sym_function_head_repeat1,
+  [509] = 1,
+    ACTIONS(69), 3,
+      ts_builtin_sym_end,
+      anon_sym_PIPE,
+      sym_identifier,
+  [515] = 3,
+    ACTIONS(78), 1,
+      sym_constructor,
+    STATE(24), 1,
+      sym_alternative,
+    STATE(47), 1,
+      sym_pattern,
+  [525] = 1,
+    ACTIONS(85), 2,
+      ts_builtin_sym_end,
+      sym_identifier,
+  [530] = 1,
+    ACTIONS(42), 2,
+      ts_builtin_sym_end,
+      sym_identifier,
+  [535] = 1,
+    ACTIONS(87), 2,
+      ts_builtin_sym_end,
+      sym_identifier,
+  [540] = 1,
+    ACTIONS(89), 1,
+      anon_sym_DASH_GT,
+  [544] = 1,
+    ACTIONS(91), 1,
+      sym_identifier,
+  [548] = 1,
+    ACTIONS(93), 1,
+      anon_sym_DASH_GT,
+  [552] = 1,
+    ACTIONS(95), 1,
+      sym_identifier,
+  [556] = 1,
+    ACTIONS(97), 1,
+      anon_sym_EQ,
+  [560] = 1,
+    ACTIONS(99), 1,
+      sym_module_name,
+  [564] = 1,
+    ACTIONS(101), 1,
+      anon_sym_EQ,
+  [568] = 1,
+    ACTIONS(103), 1,
+      ts_builtin_sym_end,
+  [572] = 1,
+    ACTIONS(105), 1,
+      anon_sym_where,
+  [576] = 1,
+    ACTIONS(107), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 18,
-  [SMALL_STATE(4)] = 28,
-  [SMALL_STATE(5)] = 38,
-  [SMALL_STATE(6)] = 56,
-  [SMALL_STATE(7)] = 68,
-  [SMALL_STATE(8)] = 82,
-  [SMALL_STATE(9)] = 98,
-  [SMALL_STATE(10)] = 115,
-  [SMALL_STATE(11)] = 134,
-  [SMALL_STATE(12)] = 151,
-  [SMALL_STATE(13)] = 168,
-  [SMALL_STATE(14)] = 187,
-  [SMALL_STATE(15)] = 195,
-  [SMALL_STATE(16)] = 205,
-  [SMALL_STATE(17)] = 217,
-  [SMALL_STATE(18)] = 231,
-  [SMALL_STATE(19)] = 239,
-  [SMALL_STATE(20)] = 255,
-  [SMALL_STATE(21)] = 265,
-  [SMALL_STATE(22)] = 275,
-  [SMALL_STATE(23)] = 285,
-  [SMALL_STATE(24)] = 295,
-  [SMALL_STATE(25)] = 301,
-  [SMALL_STATE(26)] = 311,
-  [SMALL_STATE(27)] = 321,
-  [SMALL_STATE(28)] = 331,
-  [SMALL_STATE(29)] = 341,
-  [SMALL_STATE(30)] = 347,
-  [SMALL_STATE(31)] = 353,
-  [SMALL_STATE(32)] = 363,
-  [SMALL_STATE(33)] = 373,
-  [SMALL_STATE(34)] = 383,
-  [SMALL_STATE(35)] = 393,
-  [SMALL_STATE(36)] = 398,
-  [SMALL_STATE(37)] = 402,
-  [SMALL_STATE(38)] = 406,
-  [SMALL_STATE(39)] = 410,
-  [SMALL_STATE(40)] = 414,
-  [SMALL_STATE(41)] = 418,
+  [SMALL_STATE(3)] = 28,
+  [SMALL_STATE(4)] = 46,
+  [SMALL_STATE(5)] = 60,
+  [SMALL_STATE(6)] = 72,
+  [SMALL_STATE(7)] = 82,
+  [SMALL_STATE(8)] = 98,
+  [SMALL_STATE(9)] = 108,
+  [SMALL_STATE(10)] = 121,
+  [SMALL_STATE(11)] = 130,
+  [SMALL_STATE(12)] = 147,
+  [SMALL_STATE(13)] = 164,
+  [SMALL_STATE(14)] = 181,
+  [SMALL_STATE(15)] = 190,
+  [SMALL_STATE(16)] = 207,
+  [SMALL_STATE(17)] = 222,
+  [SMALL_STATE(18)] = 239,
+  [SMALL_STATE(19)] = 250,
+  [SMALL_STATE(20)] = 262,
+  [SMALL_STATE(21)] = 274,
+  [SMALL_STATE(22)] = 290,
+  [SMALL_STATE(23)] = 306,
+  [SMALL_STATE(24)] = 317,
+  [SMALL_STATE(25)] = 328,
+  [SMALL_STATE(26)] = 339,
+  [SMALL_STATE(27)] = 350,
+  [SMALL_STATE(28)] = 361,
+  [SMALL_STATE(29)] = 372,
+  [SMALL_STATE(30)] = 383,
+  [SMALL_STATE(31)] = 394,
+  [SMALL_STATE(32)] = 405,
+  [SMALL_STATE(33)] = 416,
+  [SMALL_STATE(34)] = 427,
+  [SMALL_STATE(35)] = 438,
+  [SMALL_STATE(36)] = 449,
+  [SMALL_STATE(37)] = 460,
+  [SMALL_STATE(38)] = 471,
+  [SMALL_STATE(39)] = 481,
+  [SMALL_STATE(40)] = 489,
+  [SMALL_STATE(41)] = 499,
+  [SMALL_STATE(42)] = 509,
+  [SMALL_STATE(43)] = 515,
+  [SMALL_STATE(44)] = 525,
+  [SMALL_STATE(45)] = 530,
+  [SMALL_STATE(46)] = 535,
+  [SMALL_STATE(47)] = 540,
+  [SMALL_STATE(48)] = 544,
+  [SMALL_STATE(49)] = 548,
+  [SMALL_STATE(50)] = 552,
+  [SMALL_STATE(51)] = 556,
+  [SMALL_STATE(52)] = 560,
+  [SMALL_STATE(53)] = 564,
+  [SMALL_STATE(54)] = 568,
+  [SMALL_STATE(55)] = 572,
+  [SMALL_STATE(56)] = 576,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_let_binding, 6, .production_id = 3),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 1),
-  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_operation, 3),
-  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_body, 1),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
-  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(3),
-  [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_top_level_declarations, 1),
-  [31] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_top_level_declarations_repeat1, 2),
-  [33] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_top_level_declarations_repeat1, 2), SHIFT_REPEAT(10),
-  [36] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_top_level_declarations_repeat1, 2), SHIFT_REPEAT(26),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [53] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_declaration, 3, .production_id = 2),
-  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_function_declaration_repeat1, 2),
-  [61] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_function_declaration_repeat1, 2), SHIFT_REPEAT(28),
-  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_declaration, 2, .production_id = 1),
-  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_module_declaration, 3),
-  [68] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [72] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 2),
-  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [78] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alternative, 3, .production_id = 5),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [23] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_operation, 3),
+  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_simple_expression, 1),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [31] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_top_level_declarations, 1),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_top_level_declarations_repeat1, 2),
+  [37] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_top_level_declarations_repeat1, 2), SHIFT_REPEAT(38),
+  [40] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_let_binding, 6, .production_id = 4),
+  [42] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_body, 1),
+  [44] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [46] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_case_expression_repeat1, 2),
+  [48] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_case_expression_repeat1, 2), SHIFT_REPEAT(43),
+  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_expression, 4, .production_id = 3),
+  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alternatives, 3),
+  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_alternatives, 2),
+  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [69] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_alternatives_repeat1, 2),
+  [71] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_alternatives_repeat1, 2), SHIFT_REPEAT(40),
+  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_head, 1),
+  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [78] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [80] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_function_head_repeat1, 2),
+  [82] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_function_head_repeat1, 2), SHIFT_REPEAT(41),
+  [85] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_declaration, 3, .production_id = 1),
+  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_body, 1, .production_id = 2),
+  [89] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [91] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pattern, 1),
+  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_module_declaration, 3),
+  [97] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [99] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [103] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 2),
+  [105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [107] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
 };
 
 #ifdef __cplusplus

--- a/tree-sitter-boreal/test/corpus/case_expression.txt
+++ b/tree-sitter-boreal/test/corpus/case_expression.txt
@@ -1,13 +1,13 @@
 ================================================================================
-Let-bindings
+Case Expressions
 ================================================================================
 
-module LetIn where
+module Expressions where
 
-function = 
-  let x = 3
-   in x + 1
-
+expr x =
+  case x of
+    | True -> False
+    | False -> True
 --------------------------------------------------------------------------------
 
 (source_file
@@ -16,15 +16,20 @@ function =
   (top_level_declarations
     (function_declaration
       (function_head
+        (identifier)
         (identifier))
       (function_body
-        (let_binding
-          (identifier)
+        (case_expression
           (simple_expression
             (identifier))
-          (simple_expression
-            (binary_operation
+          (alternatives
+            (alternative
+              (pattern
+                (constructor))
               (simple_expression
-                (identifier))
+                (constructor)))
+            (alternative
+              (pattern
+                (constructor))
               (simple_expression
-                (identifier)))))))))
+                (constructor)))))))))

--- a/tree-sitter-boreal/test/corpus/expressions.txt
+++ b/tree-sitter-boreal/test/corpus/expressions.txt
@@ -1,28 +1,29 @@
-===========
+================================================================================
 Expressions
-===========
+================================================================================
 
 module Expressions where
 
 expr x = x * 2 + 3
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (module_declaration
     (module_name))
   (top_level_declarations
     (function_declaration
-      (identifier)
-      (identifier)
+      (function_head
+        (identifier)
+        (identifier))
       (function_body
-        (expression
+        (simple_expression
           (binary_operation
-            (expression
+            (simple_expression
               (binary_operation
-                (expression
+                (simple_expression
                   (identifier))
-                (expression
+                (simple_expression
                   (identifier))))
-            (expression
+            (simple_expression
               (identifier))))))))


### PR DESCRIPTION
closes #10 

Introduces the syntax for case expressions:

```haskell
case <simple_expression> of
  | pattern1 -> rhs1
  | pattern2 -> rhs2 
  …
```